### PR TITLE
右键菜单的一系列改进

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -39,10 +39,10 @@
       "message": "Save"
    },
    "placeHideInput":{
-      "message": "Default ‘Only visible to you’ Tag name"
+      "message": "Default 'Only visible to you' Tag name"
    },
    "placeShowInput":{
-      "message": "Default ‘Everyone can see’ Tag name"
+      "message": "Default 'Everyone can see' Tag name"
    },
    "picDrag":{
       "message": "Drag upload the image"
@@ -63,7 +63,7 @@
       "message": "Image uploading is in progress"
    },
    "searchNow":{
-      "message": "What your search ？"
+      "message": "What are you looking for?"
    },
    "archiveSuccess":{
       "message": "Archive Success 😊"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -9,7 +9,13 @@
       "message": "memos: A lightweight, self-hosted memo hub."
    },
    "sendTo": {
-      "message": "SendTo Memos "
+      "message": "SendTo Memos \"%s\""
+   },
+   "sendLinkTo": {
+      "message": "Send link to Memos"
+   },
+   "sendImageTo": {
+      "message": "Send image to Memos"
    },
    "saveBtn":{
       "message": "Save"
@@ -52,6 +58,9 @@
    },
    "picFailed":{
       "message": "Uploading failed"
+   },
+   "picPending":{
+      "message": "Image uploading is in progress"
    },
    "searchNow":{
       "message": "What your search ？"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -9,7 +9,13 @@
       "message": "一键发送灵感时刻，珍藏你的记忆"
    },
    "sendTo": {
-      "message": "发送至 Memos "
+      "message": "发送至 Memos “%s”"
+   },
+   "sendLinkTo": {
+      "message": "发送链接至 Memos"
+   },
+   "sendImageTo": {
+      "message": "发送图片至 Memos"
    },
    "saveBtn":{
       "message": "保存"
@@ -52,6 +58,9 @@
    },
    "picFailed":{
       "message": "上传图片失败"
+   },
+   "picPending":{
+      "message": "有图片等待上传"
    },
    "saveSuccess":{
       "message": "保存信息成功"

--- a/js/background.js
+++ b/js/background.js
@@ -2,14 +2,46 @@ chrome.runtime.onInstalled.addListener(() => {
     chrome.contextMenus.create(
       {
         type: 'normal',
-        title: chrome.i18n.getMessage("sendTo") + '“%s”',
-        id: 'Memos-send',
-        contexts: ['all']
+        title: chrome.i18n.getMessage("sendTo"),
+        id: 'Memos-send-selection',
+        contexts: ['selection']
+      },
+    )
+    chrome.contextMenus.create(
+      {
+        type: 'normal',
+        title: chrome.i18n.getMessage("sendLinkTo"),
+        id: 'Memos-send-link',
+        contexts: ['link', 'page']
+      },
+    )
+    chrome.contextMenus.create(
+      {
+        type: 'normal',
+        title: chrome.i18n.getMessage("sendImageTo"),
+        id: 'Memos-send-image',
+        contexts: ['image']
       },
     )
 })
-let tempCont=''
 chrome.contextMenus.onClicked.addListener(info => {
-    tempCont += info.selectionText + '\n'
-    chrome.storage.sync.set({open_action: "save_text",open_content:tempCont});
+    let tempCont=''
+    switch(info.menuItemId){
+      case 'Memos-send-selection':
+        tempCont = info.selectionText + '\n'
+        break
+      case 'Memos-send-link':
+        tempCont = (info.linkUrl || info.pageUrl) + '\n'
+        break
+      case 'Memos-send-image':
+        tempCont = `![](${info.srcUrl})` + '\n'
+        break
+    }
+    chrome.storage.sync.get({open_action: "save_text", open_content: ''}, function(items) {
+      if(items.open_action === 'upload_image') {
+        alert(chrome.i18n.getMessage("picPending"));
+      } else {
+        chrome.storage.sync.set({open_action: "save_text", open_content: items.open_content + tempCont});
+      }
+    })
 })


### PR DESCRIPTION
- 修复了没选择文本时划词发送菜单仍然显示且发送`undefined`的问题
- 修复了刷新页面后重新划词会导致原有内容被重置的问题
- 修复了“划词-清空内容-划词”操作后被清空的内容重新出现的问题
- 添加链接、图片和页面空白处的右键菜单，功能为发送对应的URL到Memos
  - 对于带链接的图片，用户可以自行选择发送链接还是图片

注：右键发送图片没有使用现有的资源库上传接口（个人认为对于快速记录来讲没有必要），而是用markdown图片语法直接把图片链接嵌在了文本里。

Fixes #16.