### PR TITLE
bugfix: 修复初始化状态下主页网址输入框提示词丢失问题

### DIFF
--- a/js/oper.js
+++ b/js/oper.js
@@ -23,9 +23,6 @@ function get_info(callback) {
         flag = true
       }
       returnObject.status = flag
-      if (!items.apiUrl.endsWith('/')) {
-        items.apiUrl += '/';
-      }
       returnObject.apiUrl = items.apiUrl
       returnObject.apiTokens = items.apiTokens
       returnObject.hidetag = items.hidetag
@@ -212,6 +209,9 @@ function uploadImage(data) {
 
 $('#saveKey').click(function () {
   var apiUrl = $('#apiUrl').val()
+  if (apiUrl.length > 0 && !apiUrl.endsWith('/')) {
+    apiUrl += '/';
+  }
   var apiTokens = $('#apiTokens').val()
   // 设置请求参数
   const settings = {


### PR DESCRIPTION
1. 修复默认状态下自动拼接'/' 字符导致初始状态提示信息丢失问题
![image](https://github.com/user-attachments/assets/58c828a6-7bc0-42c0-8ba7-7700162b471f)
2. 修复提交 token 时没有自动添加'/' 问题