### PR TITLE
修复身份验证和标签获取问题，适配v0.26.0，不兼容旧版

### DIFF
--- a/js/oper.js
+++ b/js/oper.js
@@ -247,18 +247,17 @@ $('#saveKey').click(function () {
   const settings = {
     async: true,
     crossDomain: true,
-    url: apiUrl + 'api/v1/auth/status',
-    method: 'POST',
+    url: apiUrl + 'api/v1/auth/me',
+    method: 'GET',
     headers: {
       'Authorization': 'Bearer ' + apiTokens
     }
   };
 
   $.ajax(settings).done(function (response) {
-    // 0.24 版本后无 id 字段，改为从 name 字段获取和判断认证是否成功
-    if (response && response.name) {
+    if (response && response.user && response.user.name) {
       // 如果响应包含用户name "users/{id}"，存储 apiUrl 和 apiTokens
-      var userid = parseInt(response.name.split('/').pop(), 10)
+      var userid = parseInt(response.user.name.split('/').pop(), 10)
       chrome.storage.sync.set(
         {
           apiUrl: apiUrl,
@@ -292,13 +291,10 @@ $('#opensite').click(function () {
   })
 })
 
-// 0.23.1版本 GET api/v1/{parent}/tags 接口已移除，参考 https://github.com/usememos/memos/issues/4161 
 $('#tags').click(function () {
   get_info(function (info) {
     if (info.apiUrl) {
-      var parent = `users/${info.userid}`;
-      // 从最近的1000条memo中获取tags,因此不保证获取能全部的
-      var tagUrl = info.apiUrl + 'api/v1/' + parent + '/memos?pageSize=1000';
+      var tagUrl = info.apiUrl + 'api/v1/memos';
       var tagDom = "";
       $.ajax({
         url: tagUrl,
@@ -306,6 +302,11 @@ $('#tags').click(function () {
         contentType: "application/json",
         dataType: "json",
         headers: { 'Authorization': 'Bearer ' + info.apiTokens },
+        data: {
+          'filter': `creator_id == ${info.userid}`,
+          // 从最近的1000条memo中获取tags,因此不保证获取能全部的
+          'page_size': 1000
+        },
         success: function (data) {
           // 提前并去重所有标签
           const allTags = data.memos.flatMap(memo => memo.tags);


### PR DESCRIPTION
如题。

取代 #60 （该PR只兼容v0.25.0，且未考虑过滤用户的问题）。
修复/Fixes #59.
